### PR TITLE
fix: pages without meta tags should not be checked

### DIFF
--- a/index.js
+++ b/index.js
@@ -539,7 +539,7 @@ function readPage(arg) {
 }
 //排除测试页面及include页面
 function standardPage(page,checkResult) {
-    if($('head').text() == ''){
+    if($('head meta').length === 0){
         checkResult['pageStandard'] ='false';
     }else{
         checkResult['pageStandard'] ='true';


### PR DESCRIPTION
The browsers will not auto-generate meta tags for partial pages, but they will auto move styles to head.

Change exclude check logic from `$('head').text()` to `$('head meta').length` could fix allanguys/tgt-pkg#2.